### PR TITLE
remove unused computed from listbox example

### DIFF
--- a/src/prose/features/interfaces/listbox.md
+++ b/src/prose/features/interfaces/listbox.md
@@ -136,7 +136,7 @@ Here's a more complete example of how to use your `listbox` and bind the various
 </template>
 
 <script setup>
-import { ref, computed } from 'vue'
+import { ref } from 'vue'
 import { useListbox } from '@baleada/vue-features'
 
 const options = ref([


### PR DESCRIPTION
While exploring the Listbox docs, I noticed computed is declared but never used.

https://github.com/baleada/docs/blob/d09d557765bbbef505bcfad36bd343a55eff3ac3/src/prose/features/interfaces/listbox.md?plain=1#L139